### PR TITLE
Configure RenovateBot automerge

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,29 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended"
+  ],
+  "lockFileMaintenance": {
+    "enabled": true,
+    "automerge": true
+  },
+  "packageRules": [
+    {
+      "matchUpdateTypes": ["minor", "patch"],
+      "automerge": true
+    },
+    {
+      "matchPackageNames": [
+        "@ember/test-helpers",
+        "ember-qunit"
+      ],
+      "matchPackagePatterns": [
+        "^eslint",
+        "^prettier",
+        "^stylelint",
+        "^qunit",
+        "^ember-template-lint"
+      ],
+      "automerge": true
+    }
   ]
 }


### PR DESCRIPTION
## Summary

Extends `renovate.json` with three automerge rules:

- **Minor and patch upgrades** — any dependency bump that is not a major version is automerged
- **Lockfile maintenance** — enables the periodic lockfile-refresh PRs that Renovate generates and automerges them
- **Linters and testers** — automerges upgrades to `eslint*`, `prettier*`, `stylelint*`, `ember-template-lint*`, `qunit*`, `@ember/test-helpers`, and `ember-qunit` regardless of update type (covers major bumps of these low-risk tooling packages)

## Test plan

- [ ] Verify the config is valid at https://docs.renovatebot.com/config-validator/
- [ ] Confirm Renovate picks up the new rules on its next run and automerges an eligible PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)