### PR TITLE
Move @glimmer/component and @glimmer/tracking to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,8 @@
   "homepage": "https://miguelcobain.github.io/ember-leaflet/",
   "devDependencies": {
     "@babel/eslint-parser": "^7.25.1",
+    "@glimmer/component": "^1.1.2",
+    "@glimmer/tracking": "^1.1.2",
     "@babel/plugin-proposal-decorators": "^7.24.7",
     "@ember/optional-features": "^2.1.0",
     "@ember/string": "^3.1.1",
@@ -77,8 +79,6 @@
   "dependencies": {
     "@babel/core": "^7.25.2",
     "@babel/plugin-transform-class-static-block": "^7.29.7",
-    "@glimmer/component": "^1.1.2",
-    "@glimmer/tracking": "^1.1.2",
     "broccoli-funnel": "^3.0.8",
     "broccoli-merge-trees": "^4.2.0",
     "ember-auto-import": "^2.8.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,12 +20,6 @@ importers:
       '@babel/plugin-transform-class-static-block':
         specifier: ^7.29.7
         version: 7.29.7(@babel/core@7.29.7)
-      '@glimmer/component':
-        specifier: ^1.1.2
-        version: 1.1.2(@babel/core@7.29.7)
-      '@glimmer/tracking':
-        specifier: ^1.1.2
-        version: 1.1.2
       broccoli-funnel:
         specifier: ^3.0.8
         version: 3.0.8
@@ -72,6 +66,12 @@ importers:
       '@embroider/test-setup':
         specifier: ^4.0.0
         version: 4.0.0
+      '@glimmer/component':
+        specifier: ^1.1.2
+        version: 1.1.2(@babel/core@7.29.7)
+      '@glimmer/tracking':
+        specifier: ^1.1.2
+        version: 1.1.2
       broccoli-asset-rev:
         specifier: ^3.0.0
         version: 3.0.0


### PR DESCRIPTION
## Summary

Per Ember ecosystem convention, `@glimmer/component` and `@glimmer/tracking` should not appear in an addon's `dependencies` or `peerDependencies`. Consumers receive both as AMD modules bundled into `ember-source`'s `vendor.js` — no explicit npm dependency is required on their side.

Both packages are moved to `devDependencies` so the dummy app continues to build during addon development. The reason a devDependency entry is still needed: pnpm's strict module isolation only exposes packages that are direct project dependencies at the root `node_modules`. Without explicit entries, `ember-auto-import`'s webpack pass errors when it encounters `@glimmer/*` imports in the dummy app controllers, because the packages are no longer resolvable from the project root.

## Test plan

- [x] `pnpm lint` passes
- [x] `ember test` passes (67 pass, 3 skip, 0 fail)

Closes #699

🤖 Generated with [Claude Code](https://claude.com/claude-code)