### PR TITLE
drop support for Ember < 4.12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,6 @@ jobs:
       fail-fast: false
       matrix:
         try-scenario:
-          - ember-lts-3.28-leaflet-0.7.7
           - ember-lts-4.12
           - ember-lts-5.12
           - ember-lts-6.12

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Ember-Leaflet aims to make working with Leaflet layers in your Ember app as easy
 
 ## Installation
 
-Ember Leaflet requires Ember 3.28+.
+Ember Leaflet requires Ember 4.12+.
 
 To install it run:
 

--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "resolve": "^1.21.0"
   },
   "peerDependencies": {
-    "ember-source": ">= 3.28.0",
+    "ember-source": ">= 4.12.0",
     "leaflet": ">=0.7"
   },
   "fastbootDependencies": [

--- a/tests/dummy/config/ember-try.js
+++ b/tests/dummy/config/ember-try.js
@@ -8,18 +8,6 @@ module.exports = async function () {
     packageManager: 'pnpm',
     scenarios: [
       {
-        name: 'ember-lts-3.28-leaflet-0.7.7',
-        npm: {
-          devDependencies: {
-            'ember-cli': '~4.12.0',
-            'ember-source': '~3.28',
-            'ember-leaflet-marker-cluster': '0.2.0',
-            'ember-resolver': '^8.1.0',
-            leaflet: '~0.7.7'
-          }
-        }
-      },
-      {
         name: 'ember-lts-4.12',
         npm: {
           devDependencies: {


### PR DESCRIPTION
Ember 3.28 reached end of life in January 2023. That's 3 1/2 years ago.

Ember 4.8 reached end of life in December 2023. That's more than 2 1/2 years ago.

Supporting compatibility those releases which reached end of life years ago increases maintenance costs. We are short on maintainer time for this addon. It's time to drop support for those very old releases.