### PR TITLE
drop support for Leaflet < 1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,13 +14,6 @@ ember install ember-leaflet
 
 This will also add the `leaflet` package to your project.
 
-ember-leaflet is compatible with leaflet 0.7+. If you need to use a legacy version, you can just install it via npm / yarn:
-
-```
-npm install --save-dev leaflet@0.7
-yarn add -D leaflet@0.7
-```
-
 ## Support, Questions, Collaboration
 
 ![Discord](https://img.shields.io/discord/480462759797063690.svg?logo=discord) Join Ember on [Discord](https://discord.gg/zT3asNS)

--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
   },
   "peerDependencies": {
     "ember-source": ">= 4.12.0",
-    "leaflet": ">=0.7"
+    "leaflet": ">= 1.0"
   },
   "fastbootDependencies": [
     "crypto"

--- a/tests/helpers/is-leaflet-0.7.js
+++ b/tests/helpers/is-leaflet-0.7.js
@@ -1,3 +1,0 @@
-export default function (L) {
-  return /0.7.\d+/.test(L.version);
-}

--- a/tests/integration/components/popup-test.js
+++ b/tests/integration/components/popup-test.js
@@ -9,7 +9,6 @@ import MarkerLayerComponent from 'ember-leaflet/components/marker-layer';
 import PolylineLayerComponent from 'ember-leaflet/components/polyline-layer';
 import locations from '../../helpers/locations';
 /* global L */
-import isLeaflet07 from '../../helpers/is-leaflet-0.7';
 
 // Needed to silence leaflet autodetection error
 L.Icon.Default.imagePath = 'some-path';
@@ -213,7 +212,7 @@ module('Integration | Component | popup layer', function (hooks) {
     assert.strictEqual(arrayPath._layer._popup.options.className, 'exists', 'popup class set on array-path');
   });
 
-  (isLeaflet07(L) ? skip : test)('popup is compatible with markerClusterLayer', async function (assert) {
+  test('popup is compatible with markerClusterLayer', async function (assert) {
     this.set('markerCenter', locations.nyc);
 
     await render(hbs`<LeafletMap @maxZoom={{16}} @zoom={{this.zoom}} @center={{this.center}} as |layers|>

--- a/tests/integration/components/popup-test.js
+++ b/tests/integration/components/popup-test.js
@@ -1,7 +1,7 @@
 import { computed, defineProperty } from '@ember/object';
 import { run } from '@ember/runloop';
 import { A } from '@ember/array';
-import { module, test, skip } from 'qunit';
+import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render, settled, click } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';

--- a/tests/integration/components/tooltip-test.js
+++ b/tests/integration/components/tooltip-test.js
@@ -9,7 +9,6 @@ import MarkerLayerComponent from 'ember-leaflet/components/marker-layer';
 import PolylineLayerComponent from 'ember-leaflet/components/polyline-layer';
 import locations from '../../helpers/locations';
 /* global L */
-import isLeaflet07 from '../../helpers/is-leaflet-0.7';
 
 // Needed to silence leaflet autodetection error
 L.Icon.Default.imagePath = 'some-path';
@@ -29,19 +28,18 @@ PolylineLayerComponent.prototype.didCreateLayer = function () {
   return polylineOldDidCreateLayer.apply(this, arguments);
 };
 
-if (!isLeaflet07(L)) {
-  module('Integration | Component | tooltip layer', function (hooks) {
-    setupRenderingTest(hooks);
+module('Integration | Component | tooltip layer', function (hooks) {
+  setupRenderingTest(hooks);
 
-    hooks.beforeEach(function () {
-      this.set('center', locations.nyc);
-      this.set('zoom', 13);
-    });
+  hooks.beforeEach(function () {
+    this.set('center', locations.nyc);
+    this.set('zoom', 13);
+  });
 
-    test('tooltip works', async function (assert) {
-      this.set('markerCenter', locations.nyc);
+  test('tooltip works', async function (assert) {
+    this.set('markerCenter', locations.nyc);
 
-      await render(hbs`<LeafletMap @zoom={{this.zoom}} @center={{this.center}} as |layers|>
+    await render(hbs`<LeafletMap @zoom={{this.zoom}} @center={{this.center}} as |layers|>
   <layers.marker @location={{this.markerCenter}} as |marker|>
     <marker.tooltip>
       Tooltip content
@@ -49,22 +47,22 @@ if (!isLeaflet07(L)) {
   </layers.marker>
 </LeafletMap>`);
 
-      assert.strictEqual(marker._layer._tooltip._map, undefined, 'tooltip not added until opened');
+    assert.strictEqual(marker._layer._tooltip._map, undefined, 'tooltip not added until opened');
 
-      run(() => {
-        marker._layer.fire('mouseover', { latlng: locations.nyc });
-      });
-
-      await settled();
-
-      assert.ok(!!marker._layer._tooltip._map, 'tooltip opened');
-      assert.dom(marker._layer._tooltip._contentNode).hasText('Tooltip content', 'tooltip content set');
+    run(() => {
+      marker._layer.fire('mouseover', { latlng: locations.nyc });
     });
 
-    test('tooltip works with permanent=true', async function (assert) {
-      this.set('markerCenter', locations.nyc);
+    await settled();
 
-      await render(hbs`<LeafletMap @zoom={{this.zoom}} @center={{this.center}} as |layers|>
+    assert.ok(!!marker._layer._tooltip._map, 'tooltip opened');
+    assert.dom(marker._layer._tooltip._contentNode).hasText('Tooltip content', 'tooltip content set');
+  });
+
+  test('tooltip works with permanent=true', async function (assert) {
+    this.set('markerCenter', locations.nyc);
+
+    await render(hbs`<LeafletMap @zoom={{this.zoom}} @center={{this.center}} as |layers|>
   <layers.marker @location={{this.markerCenter}} as |marker|>
     <marker.tooltip @permanent={{true}}>
       Tooltip content
@@ -72,24 +70,24 @@ if (!isLeaflet07(L)) {
   </layers.marker>
 </LeafletMap>`);
 
-      assert.ok(!!marker._layer._tooltip._map, 'tooltip opened');
-      assert.dom(marker._layer._tooltip._contentNode).hasText('Tooltip content', 'tooltip content set');
-    });
+    assert.ok(!!marker._layer._tooltip._map, 'tooltip opened');
+    assert.dom(marker._layer._tooltip._contentNode).hasText('Tooltip content', 'tooltip content set');
+  });
 
-    test("tooltip content isn't rendered until it is opened (lazy tooltips)", async function (assert) {
-      let didRun = false;
+  test("tooltip content isn't rendered until it is opened (lazy tooltips)", async function (assert) {
+    let didRun = false;
 
-      this.set('markerCenter', locations.nyc);
-      defineProperty(
-        this,
-        'computedProperty',
-        computed(function () {
-          didRun = true;
-          return 'text';
-        })
-      );
+    this.set('markerCenter', locations.nyc);
+    defineProperty(
+      this,
+      'computedProperty',
+      computed(function () {
+        didRun = true;
+        return 'text';
+      })
+    );
 
-      await render(hbs`<LeafletMap @zoom={{this.zoom}} @center={{this.center}} as |layers|>
+    await render(hbs`<LeafletMap @zoom={{this.zoom}} @center={{this.center}} as |layers|>
   <layers.marker @location={{this.markerCenter}} as |marker|>
     <marker.tooltip>
       {{this.computedProperty}}
@@ -97,25 +95,25 @@ if (!isLeaflet07(L)) {
   </layers.marker>
 </LeafletMap>`);
 
-      assert.strictEqual(marker._layer._tooltip._map, undefined, 'tooltip not added until opened');
+    assert.strictEqual(marker._layer._tooltip._map, undefined, 'tooltip not added until opened');
 
-      assert.notOk(didRun, 'computed property did not run');
+    assert.notOk(didRun, 'computed property did not run');
 
-      run(() => {
-        marker._layer.fire('mouseover', { latlng: locations.nyc });
-      });
-
-      await settled();
-
-      assert.ok(!!marker._layer._tooltip._map, 'tooltip opened');
-      assert.ok(didRun, 'computed property did run');
+    run(() => {
+      marker._layer.fire('mouseover', { latlng: locations.nyc });
     });
 
-    test('tooltip closes when layer is destroyed', async function (assert) {
-      this.set('markerCenter', locations.nyc);
-      this.set('isVisible', true);
+    await settled();
 
-      await render(hbs`<LeafletMap @zoom={{this.zoom}} @center={{this.center}} as |layers|>
+    assert.ok(!!marker._layer._tooltip._map, 'tooltip opened');
+    assert.ok(didRun, 'computed property did run');
+  });
+
+  test('tooltip closes when layer is destroyed', async function (assert) {
+    this.set('markerCenter', locations.nyc);
+    this.set('isVisible', true);
+
+    await render(hbs`<LeafletMap @zoom={{this.zoom}} @center={{this.center}} as |layers|>
   {{#if this.isVisible}}
     <layers.marker @location={{this.markerCenter}} as |marker|>
       <marker.tooltip>
@@ -125,26 +123,26 @@ if (!isLeaflet07(L)) {
   {{/if}}
 </LeafletMap>`);
 
-      run(() => {
-        marker._layer.fire('mouseover', { latlng: locations.nyc });
-      });
-
-      await settled();
-
-      let tooltip = marker._layer._tooltip;
-      assert.ok(!!tooltip._map, 'tooltip opened');
-      assert.dom(tooltip._contentNode).hasText('Tooltip content', 'tooltip content set');
-
-      this.set('isVisible', false);
-
-      await settled();
-
-      assert.strictEqual(tooltip._map, null, 'tooltip closed');
+    run(() => {
+      marker._layer.fire('mouseover', { latlng: locations.nyc });
     });
 
-    test('tooltip options work', async function (assert) {
-      this.set('markerCenter', locations.nyc);
-      await render(hbs`<LeafletMap @zoom={{this.zoom}} @center={{this.center}} as |layers|>
+    await settled();
+
+    let tooltip = marker._layer._tooltip;
+    assert.ok(!!tooltip._map, 'tooltip opened');
+    assert.dom(tooltip._contentNode).hasText('Tooltip content', 'tooltip content set');
+
+    this.set('isVisible', false);
+
+    await settled();
+
+    assert.strictEqual(tooltip._map, null, 'tooltip closed');
+  });
+
+  test('tooltip options work', async function (assert) {
+    this.set('markerCenter', locations.nyc);
+    await render(hbs`<LeafletMap @zoom={{this.zoom}} @center={{this.center}} as |layers|>
   <layers.marker @location={{this.markerCenter}} @draggable={{this.draggable}} as |marker|>
     <marker.tooltip @className='foo'>
       Tooltip Content
@@ -152,13 +150,13 @@ if (!isLeaflet07(L)) {
   </layers.marker>
 </LeafletMap>`);
 
-      assert.strictEqual(marker._layer._tooltip.options.className, 'foo', 'tooltip class set');
-    });
+    assert.strictEqual(marker._layer._tooltip.options.className, 'foo', 'tooltip class set');
+  });
 
-    test('tooltip options within path layers', async function (assert) {
-      this.set('locations', A([locations.chicago, locations.nyc, locations.sf]));
+  test('tooltip options within path layers', async function (assert) {
+    this.set('locations', A([locations.chicago, locations.nyc, locations.sf]));
 
-      await render(hbs`<LeafletMap @zoom={{this.zoom}} @center={{this.center}} as |layers|>
+    await render(hbs`<LeafletMap @zoom={{this.zoom}} @center={{this.center}} as |layers|>
   <layers.polyline @locations={{this.locations}} as |polyline|>
     <polyline.tooltip @className='exists'>
       Tooltip content
@@ -166,7 +164,6 @@ if (!isLeaflet07(L)) {
   </layers.polyline>
 </LeafletMap>`);
 
-      assert.strictEqual(arrayPath._layer._tooltip.options.className, 'exists', 'tooltip class set on array-path');
-    });
+    assert.strictEqual(arrayPath._layer._tooltip.options.className, 'exists', 'tooltip class set on array-path');
   });
-}
+});


### PR DESCRIPTION
Leaflet 1.0 was released in September 2016. That's ~10 years ago. It's time to drop support for Leaflet 0.7.