### PR TITLE
fix deployment of docs to GitHub Pages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,7 +92,7 @@ jobs:
     if: github.event_name == 'push' && github.ref == 'refs/heads/master'
     steps:
       - name: Check out a copy of the repo
-        uses: actions/checkout@v7
+        uses: actions/checkout@v5
 
       - name: Set up Git user
         run: |


### PR DESCRIPTION
actions/checkout@6 changed how credentials are persisted:

> Improved credential security: persist-credentials now stores credentials in a separate file under $RUNNER_TEMP instead of directly in .git/config

This is most likely the root cause for deployment to fail with the following error in CI deployment job:

```
fatal: could not read Username for 'https://github.com/': No such device or address
Error: git push https://github.com/adopted-ember-addons/ember-leaflet.git gh-pages exited with nonzero status
Error: git push https://github.com/adopted-ember-addons/ember-leaflet.git gh-pages exited with nonzero status
    at ChildProcess.<anonymous> (/home/runner/work/ember-leaflet/ember-leaflet/node_modules/.pnpm/ember-cli-deploy-git@1.3.4_@babel+core@7.29.7_supports-color@10.2.2__supports-color@10.2.2/node_modules/ember-cli-deploy-git/lib/run.js:17:19)
    at ChildProcess.emit (node:events:519:28)
    at maybeClose (node:internal/child_process:1101:16)
    at ChildProcess._handle.onexit (node:internal/child_process:304:5)
```

Downgrading to `actions/checkout@5` should fix the error (assuming I correctly guessed the root cause).