### PR TITLE
Revert "migrate to actions/checkout@7 and adopt changed GitHub token handling"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,7 +92,8 @@ jobs:
     if: github.event_name == 'push' && github.ref == 'refs/heads/master'
     steps:
       - name: Check out a copy of the repo
-        uses: actions/checkout@v7
+        uses: actions/checkout@v5
+
       - name: Set up Git user
         run: |
           # Set up a Git user for committing
@@ -100,7 +101,7 @@ jobs:
           git config --global user.email "actions@users.noreply.github.com"
           # Copy the Git Auth from the local config
           git config --global "http.https://github.com/.extraheader" \
-            "AUTHORIZATION: basic $(echo -n "x-access-token:${GITHUB_TOKEN}" | base64 -w0)"
+            "$(git config --local --get http.https://github.com/.extraheader)"
       - uses: pnpm/action-setup@v6
       - name: Install Node
         uses: actions/setup-node@v7


### PR DESCRIPTION
Reverts adopted-ember-addons/ember-leaflet#788 as it was not working as expecting but breaking the deployment of the docs app on GitHub Pages.