### PR TITLE
Prettier ignore changelog generated automatically by release-plan

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -5,6 +5,7 @@
 /blueprints/*/files/
 
 # compiled output
+/CHANGELOG.md
 /dist/
 
 # misc


### PR DESCRIPTION
The changelog entries written by release-plan do not comply with Prettier defaults. And the release-plan workflow do not run Prettier after creating those. Let's consider `CHANGELOG.md` a compiled file and ignore it as a pragmatic solution.